### PR TITLE
Support printing tensors with custom names or titles ; support delimiter of multi dim tensor ; simplify code

### DIFF
--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -17,10 +17,10 @@
 
 __device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr) {
   if (name_ptr != nullptr) {
-    printf("name: %s\n", name_ptr);
+    printf("name=%s, ", name_ptr);
   }
   if (print_ptr) {
-    printf("addr: %lld\n", x);
+    printf("addr=%lld, ", x);
   }
 }
 
@@ -58,12 +58,11 @@ __global__ void PrintTensor1D(
   if (print_shape) {
     printf("shape=(%d), stride=(%d)", (int) shape_0, (int) stride_0);
   }
-  printf("[");
+  printf("\n[");
   for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
     PrintElem(x[index_0 * stride_0]);
   }
-  printf("]");
-  printf("\n");
+  printf("]\n");
 }
 
 template <typename float_t>
@@ -77,7 +76,7 @@ __global__ void PrintTensor2D(
   if (print_shape) {
     printf("shape=(%d, %d), stride=(%d, %d)", (int) shape_0, (int) shape_1, (int) stride_0, (int) stride_1);
   }
-  printf("[");
+  printf("\n[");
   for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
     printf("[");
     for (size_t index_1 = 0; index_1 < shape_1; ++index_1) {
@@ -85,8 +84,7 @@ __global__ void PrintTensor2D(
     }
     printf("], ");
   }
-  printf("]");
-  printf("\n");
+  printf("]\n");
 }
 
 template <typename float_t>
@@ -100,7 +98,7 @@ __global__ void PrintTensor3D(
   if (print_shape) {
     printf("shape=(%d, %d, %d), stride=(%d, %d, %d)", (int) shape_0, (int) shape_1, (int) shape_2, (int) stride_0, (int) stride_1, (int) stride_2);
   }
-  printf("[");
+  printf("\n[");
   for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
     printf("[");
     for (size_t index_1 = 0; index_1 < shape_1; ++index_1) {
@@ -112,8 +110,7 @@ __global__ void PrintTensor3D(
     }
     printf("], ");
   }
-  printf("]");
-  printf("\n");
+  printf("]\n");
 }
 
 void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool print_ptr, bool print_shape) {

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -15,7 +15,7 @@
       TYPE, NAME,                                                              \
       AT_DISPATCH_CASE_FLOATING_AND_REDUCED_FLOATING_TYPES(__VA_ARGS__))
 
-__device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr) {
+__device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr, const bool print_shape) {
   if (name_ptr != nullptr) {
     printf("name: %s\n", name_ptr);
   }
@@ -27,8 +27,8 @@ __device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr)
 template <typename float_t>
 __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
                                    const size_t stride_0, const size_t n,
-                                   const char* name_ptr, const bool print_ptr) {
-  PrintCommon(x, name_ptr, print_ptr);
+                                   const char* name_ptr, const bool print_ptr, const bool print_shape) {
+  PrintCommon(x, name_ptr, print_ptr, print_shape);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f, ", float(x[i * stride_0]));
   }
@@ -37,8 +37,8 @@ __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
 
 template <typename int_t>
 __global__ void PrintIntTensor1D(int_t *__restrict__ x, const size_t stride_0,
-                                 const size_t n, const char* name_ptr, const bool print_ptr) {
-  PrintCommon(x, name_ptr, print_ptr);
+                                 const size_t n, const char* name_ptr, const bool print_ptr, const bool print_shape) {
+  PrintCommon(x, name_ptr, print_ptr, print_shape);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld, ", int64_t(x[i * stride_0]));
   }
@@ -49,8 +49,8 @@ template <typename float_t>
 __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
                                    const size_t shape_0, const size_t stride_1,
                                    const size_t stride_0, const size_t n,
-                                   const char* name_ptr, const bool print_ptr) {
-  PrintCommon(x, name_ptr, print_ptr);
+                                   const char* name_ptr, const bool print_ptr, const bool print_shape) {
+  PrintCommon(x, name_ptr, print_ptr, print_shape);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f%c ",
            float(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
@@ -62,8 +62,8 @@ __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
 template <typename int_t>
 __global__ void PrintIntTensor2D(int_t *__restrict__ x, const size_t shape_0,
                                  const size_t stride_1, const size_t stride_0,
-                                 const size_t n, const char* name_ptr, const bool print_ptr) {
-  PrintCommon(x, name_ptr, print_ptr);
+                                 const size_t n, const char* name_ptr, const bool print_ptr, const bool print_shape) {
+  PrintCommon(x, name_ptr, print_ptr, print_shape);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld%c ",
            int64_t(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
@@ -77,8 +77,8 @@ __global__ void PrintFloatTensor3D(float_t *__restrict__ x,
                                    const size_t shape_1, const size_t shape_0,
                                    const size_t stride_2, const size_t stride_1,
                                    const size_t stride_0, const size_t n,
-                                   const char* name_ptr, const bool print_ptr) {
-  PrintCommon(x, name_ptr, print_ptr);
+                                   const char* name_ptr, const bool print_ptr, const bool print_shape) {
+  PrintCommon(x, name_ptr, print_ptr, print_shape);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f%c ", float(x[(i / shape_0 / shape_1) * stride_2 +
                              ((i / shape_0) % shape_1) * stride_1 +
@@ -92,8 +92,9 @@ template <typename int_t>
 __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
                                  const size_t shape_0, const size_t stride_2,
                                  const size_t stride_1, const size_t stride_0,
-                                 const size_t n, const char* name_ptr, const bool print_ptr) {
-  PrintCommon(x, name_ptr, print_ptr);
+                                 const size_t n, const char* name_ptr,
+                                 const bool print_ptr, const bool print_shape) {
+  PrintCommon(x, name_ptr, print_ptr, print_shape);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld%c ", int64_t(x[(i / shape_0 / shape_1) * stride_2 +
                                ((i / shape_0) % shape_1) * stride_1 +
@@ -114,21 +115,21 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintFloatTensor1D", ([&] {
             PrintFloatTensor1D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.stride(0), x.numel(), name_ptr, print_ptr);
+                x.data_ptr<scalar_t>(), x.stride(0), x.numel(), name_ptr, print_ptr, print_shape);
           }));
     } else if (x.dim() == 2) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintFloatTensor2D", ([&] {
             PrintFloatTensor2D<<<1, 1, 0, stream>>>(
                 x.data_ptr<scalar_t>(), x.size(1), x.stride(0), x.stride(1),
-                x.numel(), name_ptr, print_ptr);
+                x.numel(), name_ptr, print_ptr, print_shape);
           }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintFloatTensor3D", ([&] {
             PrintFloatTensor3D<<<1, 1, 0, stream>>>(
                 x.data_ptr<scalar_t>(), x.size(1), x.size(2), x.stride(0),
-                x.stride(1), x.stride(2), x.numel(), name_ptr, print_ptr);
+                x.stride(1), x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
           }));
     } else {
       // NOTE(Zihao): I'm just too lazy to do this, codegen for higher
@@ -144,21 +145,21 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor1D", ([&] {
                                    PrintIntTensor1D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.stride(0),
-                                       x.numel(), name_ptr, print_ptr);
+                                       x.numel(), name_ptr, print_ptr, print_shape);
                                  }));
     } else if (x.dim() == 2) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor2D", ([&] {
                                    PrintIntTensor2D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.size(1),
                                        x.stride(0), x.stride(1), x.numel(),
-                                       name_ptr, print_ptr);
+                                       name_ptr, print_ptr, print_shape);
                                  }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor3D", ([&] {
                                    PrintIntTensor3D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.size(1),
                                        x.size(2), x.stride(0), x.stride(1),
-                                       x.stride(2), x.numel(), name_ptr, print_ptr);
+                                       x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
                                  }));
     } else {
       // NOTE(Zihao): I'm just too lazy to do this, codegen for higher

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -24,8 +24,19 @@ __device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr,
   }
 }
 
+template <typename scalar_t>
+__device__ void PrintElem(scalar_t value) {
+    if constexpr (std::is_floating_point<scalar_t>::value) {
+      printf("%.4f, ", float(x[i * stride_0]));
+    } else if constexpr (std::is_integral<scalar_t>::value) {
+      printf("%lld, ", static_cast<long long>(x[i * stride_0]));
+    } else {
+      printf("?, ");
+    }
+}
+
 template <typename float_t>
-__global__ void PrintFloatTensor1D(float_t *__restrict__ x,
+__global__ void PrintTensor1D(float_t *__restrict__ x,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const bool print_ptr, const bool print_shape) {
   PrintCommon(x, name_ptr, print_ptr);
@@ -33,20 +44,7 @@ __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
     printf("shape=(%d), stride=(%d)", (int) n, (int) stride_0);
   }
   for (size_t i = 0; i < n; ++i) {
-    printf("%.4f, ", float(x[i * stride_0]));
-  }
-  printf("\n");
-}
-
-template <typename int_t>
-__global__ void PrintIntTensor1D(int_t *__restrict__ x, const size_t stride_0,
-                                 const size_t n, const char* name_ptr, const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr);
-  if (print_shape) {
-    printf("shape=(%d), stride=(%d)", (int) n, (int) stride_0);
-  }
-  for (size_t i = 0; i < n; ++i) {
-    printf("%lld, ", int64_t(x[i * stride_0]));
+    PrintElem(x[i * stride_0]);
   }
   printf("\n");
 }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -104,21 +104,21 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
   if (x.is_floating_point()) {
     if (x.dim() == 1) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
-          x.scalar_type(), "PrintFloatTensor1D", ([&] {
-            PrintFloatTensor1D<<<1, 1, 0, stream>>>(
+          x.scalar_type(), "PrintTensor1D", ([&] {
+            PrintTensor1D<<<1, 1, 0, stream>>>(
                 x.data_ptr<scalar_t>(), x.stride(0), x.numel(), name_ptr, print_ptr, print_shape);
           }));
     } else if (x.dim() == 2) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
-          x.scalar_type(), "PrintFloatTensor2D", ([&] {
-            PrintFloatTensor2D<<<1, 1, 0, stream>>>(
+          x.scalar_type(), "PrintTensor2D", ([&] {
+            PrintTensor2D<<<1, 1, 0, stream>>>(
                 x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.stride(0), x.stride(1),
                 x.numel(), name_ptr, print_ptr, print_shape);
           }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
-          x.scalar_type(), "PrintFloatTensor3D", ([&] {
-            PrintFloatTensor3D<<<1, 1, 0, stream>>>(
+          x.scalar_type(), "PrintTensor3D", ([&] {
+            PrintTensor3D<<<1, 1, 0, stream>>>(
                 x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.size(2), x.stride(0),
                 x.stride(1), x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
           }));
@@ -129,25 +129,25 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
     }
     cudaError_t status = cudaGetLastError();
     TORCH_CHECK(status == cudaSuccess,
-                "PrintFloatTensor failed with error " +
+                "PrintTensor failed with error " +
                     std::string(cudaGetErrorString(status)));
   } else {
     if (x.dim() == 1) {
-      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor1D", ([&] {
-                                   PrintIntTensor1D<<<1, 1, 0, stream>>>(
+      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintTensor1D", ([&] {
+                                   PrintTensor1D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.stride(0),
                                        x.numel(), name_ptr, print_ptr, print_shape);
                                  }));
     } else if (x.dim() == 2) {
-      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor2D", ([&] {
-                                   PrintIntTensor2D<<<1, 1, 0, stream>>>(
+      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintTensor2D", ([&] {
+                                   PrintTensor2D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.size(0), x.size(1),
                                        x.stride(0), x.stride(1), x.numel(),
                                        name_ptr, print_ptr, print_shape);
                                  }));
     } else if (x.dim() == 3) {
-      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor3D", ([&] {
-                                   PrintIntTensor3D<<<1, 1, 0, stream>>>(
+      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintTensor3D", ([&] {
+                                   PrintTensor3D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.size(0), x.size(1),
                                        x.size(2), x.stride(0), x.stride(1),
                                        x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
@@ -159,7 +159,7 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
     }
     cudaError_t status = cudaGetLastError();
     TORCH_CHECK(status == cudaSuccess,
-                "PrintIntTensor failed with error " +
+                "PrintTensor failed with error " +
                     std::string(cudaGetErrorString(status)));
   }
 }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -25,11 +25,20 @@ __device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr)
 }
 
 template <typename T>
+struct is_my_floating_point : std::is_floating_point<T> {};
+
+template <>
+struct is_my_floating_point<c10::Half> : std::true_type {};
+
+template <>
+struct is_my_floating_point<c10::BFloat16> : std::true_type {};
+
+template <typename T>
 struct always_false : std::false_type {};
 
 template <typename scalar_t>
 __device__ void PrintElem(scalar_t value) {
-    if constexpr (std::is_floating_point<scalar_t>::value) {
+    if constexpr (is_my_floating_point<scalar_t>::value) {
       printf("%.4f, ", float(value));
     } else if constexpr (std::is_integral<scalar_t>::value) {
       printf("%lld, ", static_cast<long long>(value));

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -58,7 +58,7 @@ __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
                                    const char* name_ptr, const bool print_ptr, const bool print_shape) {
   PrintCommon(x, name_ptr, print_ptr);
   if (print_shape) {
-    printf("shape=(%d, %d), stride=(%d, %d)", (int) shape_0, , (int) stride_0);
+    printf("shape=(%d, %d), stride=(%d, %d)", (int) shape_0, (int) shape_1, (int) stride_0, (int) stride_1);
   }
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f%c ",
@@ -73,6 +73,9 @@ __global__ void PrintIntTensor2D(int_t *__restrict__ x, const size_t shape_0,
                                  const size_t stride_1, const size_t stride_0,
                                  const size_t n, const char* name_ptr, const bool print_ptr, const bool print_shape) {
   PrintCommon(x, name_ptr, print_ptr);
+  if (print_shape) {
+    printf("shape=(%d, %d), stride=(%d, %d)", (int) shape_0, (int) shape_1, (int) stride_0, (int) stride_1);
+  }
   for (size_t i = 0; i < n; ++i) {
     printf("%lld%c ",
            int64_t(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
@@ -88,6 +91,10 @@ __global__ void PrintFloatTensor3D(float_t *__restrict__ x,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const bool print_ptr, const bool print_shape) {
   PrintCommon(x, name_ptr, print_ptr);
+  if (print_shape) {
+    printf("shape=(%d, %d, %d), stride=(%d, %d, %d)",
+        (int) shape_0, (int) shape_1, (int) shape_2, (int) stride_0, (int) stride_1, (int) stride_2);
+  }
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f%c ", float(x[(i / shape_0 / shape_1) * stride_2 +
                              ((i / shape_0) % shape_1) * stride_1 +
@@ -104,6 +111,10 @@ __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
                                  const size_t n, const char* name_ptr,
                                  const bool print_ptr, const bool print_shape) {
   PrintCommon(x, name_ptr, print_ptr);
+  if (print_shape) {
+    printf("shape=(%d, %d, %d), stride=(%d, %d, %d)",
+        (int) shape_0, (int) shape_1, (int) shape_2, (int) stride_0, (int) stride_1, (int) stride_2);
+  }
   for (size_t i = 0; i < n; ++i) {
     printf("%lld%c ", int64_t(x[(i / shape_0 / shape_1) * stride_2 +
                                ((i / shape_0) % shape_1) * stride_1 +

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -103,7 +103,7 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream(x.device().index());
   TORCH_CHECK(x.is_cuda(), "The input tensor should be a CUDA tensor");
 
-  const char* name_ptr = name_buffer.has_value() ? name_buffer->data_ptr() : nullptr;
+  const char* name_ptr = name_buffer.has_value() ? name_buffer->data_ptr::<char>() : nullptr;
 
   if (x.is_floating_point()) {
     if (x.dim() == 1) {

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -103,7 +103,7 @@ __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
   printf("\n");
 }
 
-void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool print_ptr) {
+void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool print_ptr, bool print_shape) {
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream(x.device().index());
   TORCH_CHECK(x.is_cuda(), "The input tensor should be a CUDA tensor");
 

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -28,7 +28,7 @@ template <typename float_t>
 __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr, print_shape);
+  PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f, ", float(x[i * stride_0]));
   }
@@ -38,7 +38,7 @@ __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
 template <typename int_t>
 __global__ void PrintIntTensor1D(int_t *__restrict__ x, const size_t stride_0,
                                  const size_t n, const char* name_ptr, const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr, print_shape);
+  PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld, ", int64_t(x[i * stride_0]));
   }
@@ -50,7 +50,7 @@ __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
                                    const size_t shape_0, const size_t stride_1,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr, print_shape);
+  PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f%c ",
            float(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
@@ -63,7 +63,7 @@ template <typename int_t>
 __global__ void PrintIntTensor2D(int_t *__restrict__ x, const size_t shape_0,
                                  const size_t stride_1, const size_t stride_0,
                                  const size_t n, const char* name_ptr, const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr, print_shape);
+  PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld%c ",
            int64_t(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
@@ -78,7 +78,7 @@ __global__ void PrintFloatTensor3D(float_t *__restrict__ x,
                                    const size_t stride_2, const size_t stride_1,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr, print_shape);
+  PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f%c ", float(x[(i / shape_0 / shape_1) * stride_2 +
                              ((i / shape_0) % shape_1) * stride_1 +
@@ -94,7 +94,7 @@ __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
                                  const size_t stride_1, const size_t stride_0,
                                  const size_t n, const char* name_ptr,
                                  const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr, print_shape);
+  PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld%c ", int64_t(x[(i / shape_0 / shape_1) * stride_2 +
                                ((i / shape_0) % shape_1) * stride_1 +

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -24,6 +24,9 @@ __device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr)
   }
 }
 
+template <typename T>
+struct always_false : std::false_type {};
+
 template <typename scalar_t>
 __device__ void PrintElem(scalar_t value) {
     if constexpr (std::is_floating_point<scalar_t>::value) {
@@ -31,7 +34,7 @@ __device__ void PrintElem(scalar_t value) {
     } else if constexpr (std::is_integral<scalar_t>::value) {
       printf("%lld, ", static_cast<long long>(value));
     } else {
-      static_assert(false, "unsupported scalar_t type");
+        static_assert(always_false<scalar_t>::value, "PrintElem: unsupported scalar_t type");
     }
 }
 

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -102,12 +102,12 @@ __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
   printf("\n");
 }
 
-void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name, bool print_ptr) {
+void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool print_ptr) {
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream(x.device().index());
   TORCH_CHECK(x.is_cuda(), "The input tensor should be a CUDA tensor");
 
-  const char* name_ptr = name.has_value() ? name->data_ptr() : nullptr;
-  const int name_len = name.has_value() ? name->numel() : 0;
+  const char* name_ptr = name_buffer.has_value() ? name_buffer->data_ptr() : nullptr;
+  const int name_len = name_buffer.has_value() ? name_buffer->numel() : 0;
 
   if (x.is_floating_point()) {
     if (x.dim() == 1) {

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -15,13 +15,17 @@
       TYPE, NAME,                                                              \
       AT_DISPATCH_CASE_FLOATING_AND_REDUCED_FLOATING_TYPES(__VA_ARGS__))
 
+__device__ void PrintCommon(void* x, const char* name_ptr, const int name_len, const bool print_ptr) {
+  if (print_ptr) {
+    printf("addr: %lld\n", x);
+  }
+}
+
 template <typename float_t>
 __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const int name_len, const bool print_ptr) {
-  if (print_ptr) {
-    printf("addr: %lld\n", x);
-  }
+  PrintCommon(x, name_ptr, name_len, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f, ", float(x[i * stride_0]));
   }
@@ -31,9 +35,7 @@ __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
 template <typename int_t>
 __global__ void PrintIntTensor1D(int_t *__restrict__ x, const size_t stride_0,
                                  const size_t n, const char* name_ptr, const int name_len, const bool print_ptr) {
-  if (print_ptr) {
-    printf("addr: %lld\n", x);
-  }
+  PrintCommon(x, name_ptr, name_len, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld, ", int64_t(x[i * stride_0]));
   }
@@ -45,9 +47,7 @@ __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
                                    const size_t shape_0, const size_t stride_1,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const int name_len, const bool print_ptr) {
-  if (print_ptr) {
-    printf("addr: %lld\n", x);
-  }
+  PrintCommon(x, name_ptr, name_len, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f, ",
            float(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]));
@@ -59,9 +59,7 @@ template <typename int_t>
 __global__ void PrintIntTensor2D(int_t *__restrict__ x, const size_t shape_0,
                                  const size_t stride_1, const size_t stride_0,
                                  const size_t n, const char* name_ptr, const int name_len, const bool print_ptr) {
-  if (print_ptr) {
-    printf("addr: %lld\n", x);
-  }
+  PrintCommon(x, name_ptr, name_len, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld, ",
            int64_t(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]));
@@ -75,9 +73,7 @@ __global__ void PrintFloatTensor3D(float_t *__restrict__ x,
                                    const size_t stride_2, const size_t stride_1,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const int name_len, const bool print_ptr) {
-  if (print_ptr) {
-    printf("addr: %lld\n", x);
-  }
+  PrintCommon(x, name_ptr, name_len, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f, ", float(x[(i / shape_0 / shape_1) * stride_2 +
                              ((i / shape_0) % shape_1) * stride_1 +
@@ -91,9 +87,7 @@ __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
                                  const size_t shape_0, const size_t stride_2,
                                  const size_t stride_1, const size_t stride_0,
                                  const size_t n, const char* name_ptr, const int name_len, const bool print_ptr) {
-  if (print_ptr) {
-    printf("addr: %lld\n", x);
-  }
+  PrintCommon(x, name_ptr, name_len, print_ptr);
   for (size_t i = 0; i < n; ++i) {
     printf("%lld, ", int64_t(x[(i / shape_0 / shape_1) * stride_2 +
                                ((i / shape_0) % shape_1) * stride_1 +

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -27,9 +27,9 @@ __device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr,
 template <typename scalar_t>
 __device__ void PrintElem(scalar_t value) {
     if constexpr (std::is_floating_point<scalar_t>::value) {
-      printf("%.4f, ", float(x[i * stride_0]));
+      printf("%.4f, ", float(value));
     } else if constexpr (std::is_integral<scalar_t>::value) {
-      printf("%lld, ", static_cast<long long>(x[i * stride_0]));
+      printf("%lld, ", static_cast<long long>(value));
     } else {
       printf("?, ");
     }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -18,7 +18,7 @@
 template <typename float_t>
 __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
                                    const size_t stride_0, const size_t n,
-                                   const bool print_ptr) {
+                                   const char* name_ptr, const int name_len, const bool print_ptr) {
   if (print_ptr) {
     printf("addr: %lld\n", x);
   }
@@ -30,7 +30,7 @@ __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
 
 template <typename int_t>
 __global__ void PrintIntTensor1D(int_t *__restrict__ x, const size_t stride_0,
-                                 const size_t n, const bool print_ptr) {
+                                 const size_t n, const char* name_ptr, const int name_len, const bool print_ptr) {
   if (print_ptr) {
     printf("addr: %lld\n", x);
   }
@@ -44,7 +44,7 @@ template <typename float_t>
 __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
                                    const size_t shape_0, const size_t stride_1,
                                    const size_t stride_0, const size_t n,
-                                   const bool print_ptr) {
+                                   const char* name_ptr, const int name_len, const bool print_ptr) {
   if (print_ptr) {
     printf("addr: %lld\n", x);
   }
@@ -58,7 +58,7 @@ __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
 template <typename int_t>
 __global__ void PrintIntTensor2D(int_t *__restrict__ x, const size_t shape_0,
                                  const size_t stride_1, const size_t stride_0,
-                                 const size_t n, const bool print_ptr) {
+                                 const size_t n, const char* name_ptr, const int name_len, const bool print_ptr) {
   if (print_ptr) {
     printf("addr: %lld\n", x);
   }
@@ -74,7 +74,7 @@ __global__ void PrintFloatTensor3D(float_t *__restrict__ x,
                                    const size_t shape_1, const size_t shape_0,
                                    const size_t stride_2, const size_t stride_1,
                                    const size_t stride_0, const size_t n,
-                                   const bool print_ptr) {
+                                   const char* name_ptr, const int name_len, const bool print_ptr) {
   if (print_ptr) {
     printf("addr: %lld\n", x);
   }
@@ -90,7 +90,7 @@ template <typename int_t>
 __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
                                  const size_t shape_0, const size_t stride_2,
                                  const size_t stride_1, const size_t stride_0,
-                                 const size_t n, const bool print_ptr) {
+                                 const size_t n, const char* name_ptr, const int name_len, const bool print_ptr) {
   if (print_ptr) {
     printf("addr: %lld\n", x);
   }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -103,7 +103,7 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream(x.device().index());
   TORCH_CHECK(x.is_cuda(), "The input tensor should be a CUDA tensor");
 
-  const char* name_ptr = name_buffer.has_value() ? name_buffer->data_ptr<char>() : nullptr;
+  const char* name_ptr = name_buffer.has_value() ? reinterpret_cast<char*>(name_buffer->data_ptr<uint8_t>()) : nullptr;
 
   if (x.is_floating_point()) {
     if (x.dim() == 1) {

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -102,9 +102,12 @@ __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
   printf("\n");
 }
 
-void PrintTensor(torch::Tensor x, bool print_ptr) {
+void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name, bool print_ptr) {
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream(x.device().index());
   TORCH_CHECK(x.is_cuda(), "The input tensor should be a CUDA tensor");
+
+  const char* name_ptr = name.has_value() ? name->data_ptr() : nullptr;
+
   if (x.is_floating_point()) {
     if (x.dim() == 1) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -71,7 +71,7 @@ __global__ void PrintTensor2D(
     for (size_t index_1 = 0; index_1 < shape_1; ++index_1) {
       PrintElem(x[index_0 * stride_0 + index_1 * stride_1]);
     }
-    printf("]");
+    printf("], ");
   }
   printf("]");
   printf("\n");
@@ -96,9 +96,9 @@ __global__ void PrintTensor3D(
       for (size_t index_2 = 0; index_2 < shape_2; ++index_2) {
         PrintElem(x[index_0 * stride_0 + index_1 * stride_1]);
       }
-      printf("]");
+      printf("], ");
     }
-    printf("]");
+    printf("], ");
   }
   printf("]");
   printf("\n");

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -101,67 +101,33 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
 
   const char* name_ptr = name_buffer.has_value() ? reinterpret_cast<char*>(name_buffer->data_ptr<uint8_t>()) : nullptr;
 
-  if (x.is_floating_point()) {
-    if (x.dim() == 1) {
-      AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
-          x.scalar_type(), "PrintFloatTensor1D", ([&] {
-            PrintFloatTensor1D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.stride(0), x.numel(), name_ptr, print_ptr, print_shape);
-          }));
-    } else if (x.dim() == 2) {
-      AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
-          x.scalar_type(), "PrintFloatTensor2D", ([&] {
-            PrintFloatTensor2D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.stride(0), x.stride(1),
-                x.numel(), name_ptr, print_ptr, print_shape);
-          }));
-    } else if (x.dim() == 3) {
-      AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
-          x.scalar_type(), "PrintFloatTensor3D", ([&] {
-            PrintFloatTensor3D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.size(2), x.stride(0),
-                x.stride(1), x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
-          }));
-    } else {
-      // NOTE(Zihao): I'm just too lazy to do this, codegen for higher
-      // dimensions should be a better idea
-      TORCH_CHECK(false, "Input dimension not supported.");
-    }
-    cudaError_t status = cudaGetLastError();
-    TORCH_CHECK(status == cudaSuccess,
-                "PrintFloatTensor failed with error " +
-                    std::string(cudaGetErrorString(status)));
+  if (x.dim() == 1) {
+    AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
+        x.scalar_type(), "PrintFloatTensor1D", ([&] {
+          PrintFloatTensor1D<<<1, 1, 0, stream>>>(
+              x.data_ptr<scalar_t>(), x.stride(0), x.numel(), name_ptr, print_ptr, print_shape);
+        }));
+  } else if (x.dim() == 2) {
+    AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
+        x.scalar_type(), "PrintFloatTensor2D", ([&] {
+          PrintFloatTensor2D<<<1, 1, 0, stream>>>(
+              x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.stride(0), x.stride(1),
+              x.numel(), name_ptr, print_ptr, print_shape);
+        }));
+  } else if (x.dim() == 3) {
+    AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
+        x.scalar_type(), "PrintFloatTensor3D", ([&] {
+          PrintFloatTensor3D<<<1, 1, 0, stream>>>(
+              x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.size(2), x.stride(0),
+              x.stride(1), x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
+        }));
   } else {
-    if (x.dim() == 1) {
-      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor1D", ([&] {
-                                   PrintIntTensor1D<<<1, 1, 0, stream>>>(
-                                       x.data_ptr<scalar_t>(), x.stride(0),
-                                       x.numel(), name_ptr, print_ptr, print_shape);
-                                 }));
-    } else if (x.dim() == 2) {
-      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor2D", ([&] {
-                                   PrintIntTensor2D<<<1, 1, 0, stream>>>(
-                                       x.data_ptr<scalar_t>(), x.size(0), x.size(1),
-                                       x.stride(0), x.stride(1), x.numel(),
-                                       name_ptr, print_ptr, print_shape);
-                                 }));
-    } else if (x.dim() == 3) {
-      AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor3D", ([&] {
-                                   PrintIntTensor3D<<<1, 1, 0, stream>>>(
-                                       x.data_ptr<scalar_t>(), x.size(0), x.size(1),
-                                       x.size(2), x.stride(0), x.stride(1),
-                                       x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
-                                 }));
-    } else {
-      // NOTE(Zihao): I'm just too lazy to do this, codegen for higher
-      // dimensions should be a better idea
-      TORCH_CHECK(false, "Input dimension not supported.");
-    }
-    cudaError_t status = cudaGetLastError();
-    TORCH_CHECK(status == cudaSuccess,
-                "PrintIntTensor failed with error " +
-                    std::string(cudaGetErrorString(status)));
+    // NOTE(Zihao): I'm just too lazy to do this, codegen for higher
+    // dimensions should be a better idea
+    TORCH_CHECK(false, "Input dimension not supported.");
   }
+  cudaError_t status = cudaGetLastError();
+  TORCH_CHECK(status == cudaSuccess, "PrintTensor failed with error " + std::string(cudaGetErrorString(status)));
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -31,7 +31,7 @@ __device__ void PrintElem(scalar_t value) {
     } else if constexpr (std::is_integral<scalar_t>::value) {
       printf("%lld, ", static_cast<long long>(value));
     } else {
-      printf("?, ");
+      static_assert(false, "unsupported scalar_t type");
     }
 }
 

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -52,8 +52,9 @@ __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
                                    const char* name_ptr, const bool print_ptr) {
   PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
-    printf("%.4f, ",
-           float(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]));
+    printf("%.4f%c ",
+           float(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
+           (i % shape_0 == 0) ? ";" : ",");
   }
   printf("\n");
 }
@@ -64,8 +65,9 @@ __global__ void PrintIntTensor2D(int_t *__restrict__ x, const size_t shape_0,
                                  const size_t n, const char* name_ptr, const bool print_ptr) {
   PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
-    printf("%lld, ",
-           int64_t(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]));
+    printf("%lld%c ",
+           int64_t(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
+           (i % shape_0 == 0) ? ";" : ",");
   }
   printf("\n");
 }
@@ -78,9 +80,10 @@ __global__ void PrintFloatTensor3D(float_t *__restrict__ x,
                                    const char* name_ptr, const bool print_ptr) {
   PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
-    printf("%.4f, ", float(x[(i / shape_0 / shape_1) * stride_2 +
+    printf("%.4f%c ", float(x[(i / shape_0 / shape_1) * stride_2 +
                              ((i / shape_0) % shape_1) * stride_1 +
-                             (i % shape_0) * stride_0]));
+                             (i % shape_0) * stride_0]),
+           ((i % (shape_0 * shape_1) == 0) || (i % shape_0 == 0)) ? ";" : ",");
   }
   printf("\n");
 }
@@ -92,9 +95,10 @@ __global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
                                  const size_t n, const char* name_ptr, const bool print_ptr) {
   PrintCommon(x, name_ptr, print_ptr);
   for (size_t i = 0; i < n; ++i) {
-    printf("%lld, ", int64_t(x[(i / shape_0 / shape_1) * stride_2 +
+    printf("%lld%c ", int64_t(x[(i / shape_0 / shape_1) * stride_2 +
                                ((i / shape_0) % shape_1) * stride_1 +
-                               (i % shape_0) * stride_0]));
+                               (i % shape_0) * stride_0]),
+           ((i % (shape_0 * shape_1) == 0) || (i % shape_0 == 0)) ? ";" : ",");
   }
   printf("\n");
 }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -107,27 +107,28 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name, bool print_
   TORCH_CHECK(x.is_cuda(), "The input tensor should be a CUDA tensor");
 
   const char* name_ptr = name.has_value() ? name->data_ptr() : nullptr;
+  const int name_len = name.has_value() ? name->numel() : 0;
 
   if (x.is_floating_point()) {
     if (x.dim() == 1) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintFloatTensor1D", ([&] {
             PrintFloatTensor1D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.stride(0), x.numel(), print_ptr);
+                x.data_ptr<scalar_t>(), x.stride(0), x.numel(), name_ptr, name_len, print_ptr);
           }));
     } else if (x.dim() == 2) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintFloatTensor2D", ([&] {
             PrintFloatTensor2D<<<1, 1, 0, stream>>>(
                 x.data_ptr<scalar_t>(), x.size(1), x.stride(0), x.stride(1),
-                x.numel(), print_ptr);
+                x.numel(), name_ptr, name_len, print_ptr);
           }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintFloatTensor3D", ([&] {
             PrintFloatTensor3D<<<1, 1, 0, stream>>>(
                 x.data_ptr<scalar_t>(), x.size(1), x.size(2), x.stride(0),
-                x.stride(1), x.stride(2), x.numel(), print_ptr);
+                x.stride(1), x.stride(2), x.numel(), name_ptr, name_len, print_ptr);
           }));
     } else {
       // NOTE(Zihao): I'm just too lazy to do this, codegen for higher
@@ -143,21 +144,21 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name, bool print_
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor1D", ([&] {
                                    PrintIntTensor1D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.stride(0),
-                                       x.numel(), print_ptr);
+                                       x.numel(), name_ptr, name_len, print_ptr);
                                  }));
     } else if (x.dim() == 2) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor2D", ([&] {
                                    PrintIntTensor2D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.size(1),
                                        x.stride(0), x.stride(1), x.numel(),
-                                       print_ptr);
+                                       name_ptr, name_len, print_ptr);
                                  }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor3D", ([&] {
                                    PrintIntTensor3D<<<1, 1, 0, stream>>>(
                                        x.data_ptr<scalar_t>(), x.size(1),
                                        x.size(2), x.stride(0), x.stride(1),
-                                       x.stride(2), x.numel(), print_ptr);
+                                       x.stride(2), x.numel(), name_ptr, name_len, print_ptr);
                                  }));
     } else {
       // NOTE(Zihao): I'm just too lazy to do this, codegen for higher

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -106,7 +106,7 @@ __global__ void PrintTensor3D(
     for (size_t index_1 = 0; index_1 < shape_1; ++index_1) {
       printf("[");
       for (size_t index_2 = 0; index_2 < shape_2; ++index_2) {
-        PrintElem(x[index_0 * stride_0 + index_1 * stride_1]);
+        PrintElem(x[index_0 * stride_0 + index_1 * stride_1 + index_2 * stride_2]);
       }
       printf("], ");
     }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -106,21 +106,28 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintTensor1D", ([&] {
             PrintTensor1D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.stride(0), x.numel(), name_ptr, print_ptr, print_shape);
+                x.data_ptr<scalar_t>(),
+                x.size(0), x.stride(0),
+                name_ptr, print_ptr, print_shape
+            );
           }));
     } else if (x.dim() == 2) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintTensor2D", ([&] {
             PrintTensor2D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.stride(0), x.stride(1),
-                x.numel(), name_ptr, print_ptr, print_shape);
+                x.data_ptr<scalar_t>(),
+                x.size(0), x.size(1), x.stride(0), x.stride(1),
+                name_ptr, print_ptr, print_shape
+            );
           }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintTensor3D", ([&] {
             PrintTensor3D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.size(2), x.stride(0),
-                x.stride(1), x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
+                x.data_ptr<scalar_t>(),
+                x.size(0), x.size(1), x.size(2), x.stride(0), x.stride(1), x.stride(2),
+                name_ptr, print_ptr, print_shape
+            );
           }));
     } else {
       // NOTE(Zihao): I'm just too lazy to do this, codegen for higher
@@ -134,24 +141,28 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
   } else {
     if (x.dim() == 1) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintTensor1D", ([&] {
-                                   PrintTensor1D<<<1, 1, 0, stream>>>(
-                                       x.data_ptr<scalar_t>(), x.stride(0),
-                                       x.numel(), name_ptr, print_ptr, print_shape);
-                                 }));
+           PrintTensor1D<<<1, 1, 0, stream>>>(
+                x.data_ptr<scalar_t>(),
+                x.size(0), x.stride(0),
+                name_ptr, print_ptr, print_shape
+            );
+      }));
     } else if (x.dim() == 2) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintTensor2D", ([&] {
-                                   PrintTensor2D<<<1, 1, 0, stream>>>(
-                                       x.data_ptr<scalar_t>(), x.size(0), x.size(1),
-                                       x.stride(0), x.stride(1), x.numel(),
-                                       name_ptr, print_ptr, print_shape);
-                                 }));
+       PrintTensor2D<<<1, 1, 0, stream>>>(
+                x.data_ptr<scalar_t>(),
+                x.size(0), x.size(1), x.stride(0), x.stride(1),
+                name_ptr, print_ptr, print_shape
+            );
+     }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintTensor3D", ([&] {
-                                   PrintTensor3D<<<1, 1, 0, stream>>>(
-                                       x.data_ptr<scalar_t>(), x.size(0), x.size(1),
-                                       x.size(2), x.stride(0), x.stride(1),
-                                       x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
-                                 }));
+       PrintTensor3D<<<1, 1, 0, stream>>>(
+                x.data_ptr<scalar_t>(),
+                x.size(0), x.size(1), x.size(2), x.stride(0), x.stride(1), x.stride(2),
+                name_ptr, print_ptr, print_shape
+            );
+     }));
     } else {
       // NOTE(Zihao): I'm just too lazy to do this, codegen for higher
       // dimensions should be a better idea

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -15,7 +15,7 @@
       TYPE, NAME,                                                              \
       AT_DISPATCH_CASE_FLOATING_AND_REDUCED_FLOATING_TYPES(__VA_ARGS__))
 
-__device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr, const bool print_shape) {
+__device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr) {
   if (name_ptr != nullptr) {
     printf("name: %s\n", name_ptr);
   }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -44,7 +44,7 @@ __global__ void PrintTensor1D(
 ) {
   PrintCommon(x, name_ptr, print_ptr);
   if (print_shape) {
-    printf("shape=(%d), stride=(%d)", (int) n, (int) stride_0);
+    printf("shape=(%d), stride=(%d)", (int) shape_0, (int) stride_0);
   }
   for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
     PrintElem(x[index_0 * stride_0]);
@@ -53,74 +53,44 @@ __global__ void PrintTensor1D(
 }
 
 template <typename float_t>
-__global__ void PrintFloatTensor2D(float_t *__restrict__ x,
-                                   const size_t shape_0, const size_t stride_1,
-                                   const size_t stride_0, const size_t n,
-                                   const char* name_ptr, const bool print_ptr, const bool print_shape) {
+__global__ void PrintTensor2D(
+    float_t *__restrict__ x,
+    const size_t shape_0, const size_t shape_1,
+    const size_t stride_0, const size_t stride_1,
+    const char* name_ptr, const bool print_ptr, const bool print_shape
+) {
   PrintCommon(x, name_ptr, print_ptr);
   if (print_shape) {
     printf("shape=(%d, %d), stride=(%d, %d)", (int) shape_0, (int) shape_1, (int) stride_0, (int) stride_1);
   }
-  for (size_t i = 0; i < n; ++i) {
-    printf("%.4f%c ",
-           float(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
-           (i % shape_0 == 0) ? ";" : ",");
-  }
-  printf("\n");
-}
-
-template <typename int_t>
-__global__ void PrintIntTensor2D(int_t *__restrict__ x, const size_t shape_0,
-                                 const size_t stride_1, const size_t stride_0,
-                                 const size_t n, const char* name_ptr, const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr);
-  if (print_shape) {
-    printf("shape=(%d, %d), stride=(%d, %d)", (int) shape_0, (int) shape_1, (int) stride_0, (int) stride_1);
-  }
-  for (size_t i = 0; i < n; ++i) {
-    printf("%lld%c ",
-           int64_t(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
-           (i % shape_0 == 0) ? ";" : ",");
+  for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
+    for (size_t index_1 = 0; index_1 < shape_1; ++index_1) {
+      PrintElem(x[index_0 * stride_0 + index_1 * stride_1]);
+    }
+    printf("; ");
   }
   printf("\n");
 }
 
 template <typename float_t>
-__global__ void PrintFloatTensor3D(float_t *__restrict__ x,
-                                   const size_t shape_1, const size_t shape_0,
-                                   const size_t stride_2, const size_t stride_1,
-                                   const size_t stride_0, const size_t n,
-                                   const char* name_ptr, const bool print_ptr, const bool print_shape) {
+__global__ void PrintTensor3D(
+    float_t *__restrict__ x,
+    const size_t shape_0, const size_t shape_1, const size_t shape_2,
+    const size_t stride_0, const size_t stride_1, const size_t stride_2,
+    const char* name_ptr, const bool print_ptr, const bool print_shape
+) {
   PrintCommon(x, name_ptr, print_ptr);
   if (print_shape) {
-    printf("shape=(%d, %d, %d), stride=(%d, %d, %d)",
-        (int) shape_0, (int) shape_1, (int) shape_2, (int) stride_0, (int) stride_1, (int) stride_2);
+    printf("shape=(%d, %d, %d), stride=(%d, %d, %d)", (int) shape_0, (int) shape_1, (int) shape_2, (int) stride_0, (int) stride_1, (int) stride_2);
   }
-  for (size_t i = 0; i < n; ++i) {
-    printf("%.4f%c ", float(x[(i / shape_0 / shape_1) * stride_2 +
-                             ((i / shape_0) % shape_1) * stride_1 +
-                             (i % shape_0) * stride_0]),
-           ((i % (shape_0 * shape_1) == 0) || (i % shape_0 == 0)) ? ";" : ",");
-  }
-  printf("\n");
-}
-
-template <typename int_t>
-__global__ void PrintIntTensor3D(int_t *__restrict__ x, const size_t shape_1,
-                                 const size_t shape_0, const size_t stride_2,
-                                 const size_t stride_1, const size_t stride_0,
-                                 const size_t n, const char* name_ptr,
-                                 const bool print_ptr, const bool print_shape) {
-  PrintCommon(x, name_ptr, print_ptr);
-  if (print_shape) {
-    printf("shape=(%d, %d, %d), stride=(%d, %d, %d)",
-        (int) shape_0, (int) shape_1, (int) shape_2, (int) stride_0, (int) stride_1, (int) stride_2);
-  }
-  for (size_t i = 0; i < n; ++i) {
-    printf("%lld%c ", int64_t(x[(i / shape_0 / shape_1) * stride_2 +
-                               ((i / shape_0) % shape_1) * stride_1 +
-                               (i % shape_0) * stride_0]),
-           ((i % (shape_0 * shape_1) == 0) || (i % shape_0 == 0)) ? ";" : ",");
+  for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
+    for (size_t index_1 = 0; index_1 < shape_1; ++index_1) {
+      for (size_t index_2 = 0; index_2 < shape_2; ++index_2) {
+        PrintElem(x[index_0 * stride_0 + index_1 * stride_1]);
+      }
+      printf("; ");
+    }
+    printf("; ");
   }
   printf("\n");
 }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -29,6 +29,9 @@ __global__ void PrintFloatTensor1D(float_t *__restrict__ x,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const bool print_ptr, const bool print_shape) {
   PrintCommon(x, name_ptr, print_ptr);
+  if (print_shape) {
+    printf("shape=(%d), stride=(%d)", (int) n, (int) stride_0);
+  }
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f, ", float(x[i * stride_0]));
   }
@@ -39,6 +42,9 @@ template <typename int_t>
 __global__ void PrintIntTensor1D(int_t *__restrict__ x, const size_t stride_0,
                                  const size_t n, const char* name_ptr, const bool print_ptr, const bool print_shape) {
   PrintCommon(x, name_ptr, print_ptr);
+  if (print_shape) {
+    printf("shape=(%d), stride=(%d)", (int) n, (int) stride_0);
+  }
   for (size_t i = 0; i < n; ++i) {
     printf("%lld, ", int64_t(x[i * stride_0]));
   }
@@ -51,6 +57,9 @@ __global__ void PrintFloatTensor2D(float_t *__restrict__ x,
                                    const size_t stride_0, const size_t n,
                                    const char* name_ptr, const bool print_ptr, const bool print_shape) {
   PrintCommon(x, name_ptr, print_ptr);
+  if (print_shape) {
+    printf("shape=(%d, %d), stride=(%d, %d)", (int) shape_0, , (int) stride_0);
+  }
   for (size_t i = 0; i < n; ++i) {
     printf("%.4f%c ",
            float(x[(i / shape_0) * stride_1 + (i % shape_0) * stride_0]),
@@ -121,14 +130,14 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintFloatTensor2D", ([&] {
             PrintFloatTensor2D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.size(1), x.stride(0), x.stride(1),
+                x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.stride(0), x.stride(1),
                 x.numel(), name_ptr, print_ptr, print_shape);
           }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_FLOATING_AND_REDUCED_FLOATING_TYPES(
           x.scalar_type(), "PrintFloatTensor3D", ([&] {
             PrintFloatTensor3D<<<1, 1, 0, stream>>>(
-                x.data_ptr<scalar_t>(), x.size(1), x.size(2), x.stride(0),
+                x.data_ptr<scalar_t>(), x.size(0), x.size(1), x.size(2), x.stride(0),
                 x.stride(1), x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
           }));
     } else {
@@ -150,14 +159,14 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
     } else if (x.dim() == 2) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor2D", ([&] {
                                    PrintIntTensor2D<<<1, 1, 0, stream>>>(
-                                       x.data_ptr<scalar_t>(), x.size(1),
+                                       x.data_ptr<scalar_t>(), x.size(0), x.size(1),
                                        x.stride(0), x.stride(1), x.numel(),
                                        name_ptr, print_ptr, print_shape);
                                  }));
     } else if (x.dim() == 3) {
       AT_DISPATCH_INTEGRAL_TYPES(x.scalar_type(), "PrintIntTensor3D", ([&] {
                                    PrintIntTensor3D<<<1, 1, 0, stream>>>(
-                                       x.data_ptr<scalar_t>(), x.size(1),
+                                       x.data_ptr<scalar_t>(), x.size(0), x.size(1),
                                        x.size(2), x.stride(0), x.stride(1),
                                        x.stride(2), x.numel(), name_ptr, print_ptr, print_shape);
                                  }));

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -15,7 +15,10 @@
       TYPE, NAME,                                                              \
       AT_DISPATCH_CASE_FLOATING_AND_REDUCED_FLOATING_TYPES(__VA_ARGS__))
 
-__device__ void PrintCommon(void* x, const char* name_ptr, const int name_len, const bool print_ptr) {
+__device__ void PrintCommon(void* x, const char* name_ptr, const bool print_ptr) {
+  if (name_ptr != nullptr) {
+    printf("name: %s\n", name_ptr);
+  }
   if (print_ptr) {
     printf("addr: %lld\n", x);
   }

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -46,9 +46,11 @@ __global__ void PrintTensor1D(
   if (print_shape) {
     printf("shape=(%d), stride=(%d)", (int) shape_0, (int) stride_0);
   }
+  printf("[");
   for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
     PrintElem(x[index_0 * stride_0]);
   }
+  printf("]");
   printf("\n");
 }
 
@@ -63,12 +65,15 @@ __global__ void PrintTensor2D(
   if (print_shape) {
     printf("shape=(%d, %d), stride=(%d, %d)", (int) shape_0, (int) shape_1, (int) stride_0, (int) stride_1);
   }
+  printf("[");
   for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
+    printf("[");
     for (size_t index_1 = 0; index_1 < shape_1; ++index_1) {
       PrintElem(x[index_0 * stride_0 + index_1 * stride_1]);
     }
-    printf("; ");
+    printf("]");
   }
+  printf("]");
   printf("\n");
 }
 
@@ -83,15 +88,19 @@ __global__ void PrintTensor3D(
   if (print_shape) {
     printf("shape=(%d, %d, %d), stride=(%d, %d, %d)", (int) shape_0, (int) shape_1, (int) shape_2, (int) stride_0, (int) stride_1, (int) stride_2);
   }
+  printf("[");
   for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
+    printf("[");
     for (size_t index_1 = 0; index_1 < shape_1; ++index_1) {
+      printf("[");
       for (size_t index_2 = 0; index_2 < shape_2; ++index_2) {
         PrintElem(x[index_0 * stride_0 + index_1 * stride_1]);
       }
-      printf("; ");
+      printf("]");
     }
-    printf("; ");
+    printf("]");
   }
+  printf("]");
   printf("\n");
 }
 

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -103,7 +103,7 @@ void PrintTensor(torch::Tensor x, std::optional<torch::Tensor> name_buffer, bool
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream(x.device().index());
   TORCH_CHECK(x.is_cuda(), "The input tensor should be a CUDA tensor");
 
-  const char* name_ptr = name_buffer.has_value() ? name_buffer->data_ptr::<char>() : nullptr;
+  const char* name_ptr = name_buffer.has_value() ? name_buffer->data_ptr<char>() : nullptr;
 
   if (x.is_floating_point()) {
     if (x.dim() == 1) {

--- a/csrc/debug_print.cu
+++ b/csrc/debug_print.cu
@@ -36,15 +36,18 @@ __device__ void PrintElem(scalar_t value) {
 }
 
 template <typename float_t>
-__global__ void PrintTensor1D(float_t *__restrict__ x,
-                                   const size_t stride_0, const size_t n,
-                                   const char* name_ptr, const bool print_ptr, const bool print_shape) {
+__global__ void PrintTensor1D(
+    float_t *__restrict__ x,
+    const size_t shape_0,
+    const size_t stride_0,
+    const char* name_ptr, const bool print_ptr, const bool print_shape
+) {
   PrintCommon(x, name_ptr, print_ptr);
   if (print_shape) {
     printf("shape=(%d), stride=(%d)", (int) n, (int) stride_0);
   }
-  for (size_t i = 0; i < n; ++i) {
-    PrintElem(x[i * stride_0]);
+  for (size_t index_0 = 0; index_0 < shape_0; ++index_0) {
+    PrintElem(x[index_0 * stride_0]);
   }
   printf("\n");
 }

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 import torch
 from ._kernels import print_tensor as print_tensor_kernel
@@ -31,5 +31,14 @@ class _DebugPrinter:
             name_buffer.copy_(TODO)
 
 
-def print_tensor(x: torch.Tensor, print_ptr: bool = False):
-    print_tensor_kernel(x, print_ptr)
+_printer: Optional[_DebugPrinter] = None
+
+
+def initialize():
+    global _printer
+    assert _printer is None
+    _printer = _DebugPrinter()
+
+
+def print_tensor(x: torch.Tensor, name: str = "", print_ptr: bool = False):
+    _printer(x=x, name=name, print_ptr=print_ptr)

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -31,7 +31,8 @@ class _DebugPrinter:
         # Can be optimized
         self._buffers: Dict[int, _Buffer] = {
             device_index: _Buffer(device_index=device_index)
-            for device_index in range(torch.cuda.device_count())
+            # for device_index in range(torch.cuda.device_count())
+            for device_index in [torch.cuda.current_device()]
         }
         self._pending_copy_tasks: List[_CopyTask] = []
 
@@ -75,5 +76,5 @@ def post_initialize():
     _printer.post_initialize()
 
 
-def print_tensor(x: torch.Tensor, name: str = "", print_ptr: bool = False, print_shape: bool = False):
+def print_tensor(x: torch.Tensor, name: str = "", print_ptr: bool = True, print_shape: bool = True):
     _printer(x=x, name=name, print_ptr=print_ptr, print_shape=print_shape)

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -25,6 +25,10 @@ class _DebugPrinter:
         }
 
     def __call__(self, x: torch.Tensor, name: str = "", print_ptr: bool = False):
+        if len(name) > 0:
+            name_bytes = TODO
+            name_buffer = self._buffers[x.device].allocate(len(name_bytes) + 1)
+            name_buffer.copy_(TODO)
 
 
 def print_tensor(x: torch.Tensor, print_ptr: bool = False):

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -41,6 +41,7 @@ class _DebugPrinter:
         self._pending_copy_tasks.clear()
 
     def __call__(self, x: torch.Tensor, name: str, print_ptr: bool, print_shape: bool):
+        assert x.is_cuda, f"{x.device} must be on cuda"
         name_buffer_gpu = self._compute_name_buffer_gpu(name=name, device_index=x.device.index)
         _print_tensor_kernel(x, name_buffer_gpu, print_ptr, print_shape)
 

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional
 
 import torch
-from ._kernels import print_tensor as print_tensor_kernel
+from ._kernels import print_tensor as _print_tensor_kernel
 
 
 class _Buffer:
@@ -29,6 +29,9 @@ class _DebugPrinter:
             name_bytes = TODO
             name_buffer = self._buffers[x.device].allocate(len(name_bytes) + 1)
             name_buffer.copy_(TODO)
+        else:
+            name_buffer = None
+        _print_tensor_kernel(x, name_buffer, print_ptr)
 
 
 _printer: Optional[_DebugPrinter] = None

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -28,8 +28,8 @@ class _DebugPrinter:
         if len(name) > 0:
             name_bytes = name.encode("utf-8")
             name_buffer = self._buffers[x.device.index].allocate(len(name_bytes) + 1)
-            tmp = torch.empty(list(name_bytes) + [0], dtype=torch.uint8, device="cpu")
-            name_buffer.copy_(tmp.to(name_buffer.device).view(torch.char))
+            tmp = torch.empty(list(name_bytes) + [0], dtype=torch.uint8, device="cpu").to(name_buffer.device)
+            name_buffer.copy_(tmp)
         else:
             name_buffer = None
         _print_tensor_kernel(x, name_buffer, print_ptr)

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Dict, Optional
 
 import torch
@@ -16,6 +17,15 @@ class _Buffer:
         return output
 
 
+@dataclass
+class _CopyTask:
+    src: torch.Tensor
+    dst: torch.Tensor
+
+    def execute(self):
+        self.dst.copy_(self.src)
+
+
 class _DebugPrinter:
     def __init__(self):
         # Can be optimized
@@ -28,9 +38,9 @@ class _DebugPrinter:
         if len(name) > 0:
             name_bytes = name.encode("utf-8")
             name_buffer = self._buffers[x.device.index].allocate(len(name_bytes) + 1)
-            tmp = torch.tensor(list(name_bytes) + [0], dtype=torch.uint8, device="cpu")
-            tmp = tmp.to(name_buffer.device)
-            name_buffer.copy_(tmp)
+            name_cpu = torch.tensor(list(name_bytes) + [0], dtype=torch.uint8, device="cpu")
+            name_cpu = name_cpu.to(name_buffer.device)
+            name_buffer.copy_(name_cpu)
         else:
             name_buffer = None
         _print_tensor_kernel(x, name_buffer, print_ptr)

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -37,13 +37,12 @@ class _DebugPrinter:
     def __call__(self, x: torch.Tensor, name: str = "", print_ptr: bool = False):
         if len(name) > 0:
             name_bytes = name.encode("utf-8")
-            name_buffer = self._buffers[x.device.index].allocate(len(name_bytes) + 1)
+            name_buffer_gpu = self._buffers[x.device.index].allocate(len(name_bytes) + 1)
             name_cpu = torch.tensor(list(name_bytes) + [0], dtype=torch.uint8, device="cpu")
-            name_cpu = name_cpu.to(name_buffer.device)
-            name_buffer.copy_(name_cpu)
+            copy_task = _CopyTask(src=name_cpu, dst=name_buffer_gpu)
         else:
-            name_buffer = None
-        _print_tensor_kernel(x, name_buffer, print_ptr)
+            name_buffer_gpu = None
+        _print_tensor_kernel(x, name_buffer_gpu, print_ptr)
 
 
 _printer: Optional[_DebugPrinter] = None

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -28,7 +28,8 @@ class _DebugPrinter:
         if len(name) > 0:
             name_bytes = name.encode("utf-8")
             name_buffer = self._buffers[x.device.index].allocate(len(name_bytes) + 1)
-            tmp = torch.tensor(list(name_bytes) + [0], dtype=torch.uint8, device="cpu").to(name_buffer.device)
+            tmp = torch.tensor(list(name_bytes) + [0], dtype=torch.uint8, device="cpu")
+            tmp = tmp.to(name_buffer.device)
             name_buffer.copy_(tmp)
         else:
             name_buffer = None

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -1,5 +1,30 @@
+from typing import Dict
+
 import torch
 from ._kernels import print_tensor as print_tensor_kernel
+
+
+class _Buffer:
+    def __init__(self, device_index: int):
+        self._tensor = torch.zeros((10_000_000,), dtype=torch.char, device=f"cuda:{device_index}")
+        self._used_len = 0
+
+    def allocate(self, size: int):
+        output = self._tensor[self._used_len: self._used_len + size]
+        self._used_len += size
+        assert self._used_len <= len(self._tensor)
+        return output
+
+
+class _DebugPrinter:
+    def __init__(self):
+        # Can be optimized
+        self._buffers: Dict[int, _Buffer] = {
+            device_index: _Buffer(device_index=device_index)
+            for device_index in range(torch.cuda.device_count())
+        }
+
+    def __call__(self, x: torch.Tensor, name: str = "", print_ptr: bool = False):
 
 
 def print_tensor(x: torch.Tensor, print_ptr: bool = False):

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -68,7 +68,9 @@ _printer: Optional[_DebugPrinter] = None
 
 def initialize():
     global _printer
-    assert _printer is None
+    if _printer is not None:
+        print("debug_print.initialize skip since already initialized")
+        return
     _printer = _DebugPrinter()
 
 

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -28,7 +28,7 @@ class _DebugPrinter:
         if len(name) > 0:
             name_bytes = name.encode("utf-8")
             name_buffer = self._buffers[x.device.index].allocate(len(name_bytes) + 1)
-            tmp = torch.empty(list(name_bytes) + [0], dtype=torch.uint8, device="cpu").to(name_buffer.device)
+            tmp = torch.tensor(list(name_bytes) + [0], dtype=torch.uint8, device="cpu").to(name_buffer.device)
             name_buffer.copy_(tmp)
         else:
             name_buffer = None

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -6,7 +6,7 @@ from ._kernels import print_tensor as _print_tensor_kernel
 
 class _Buffer:
     def __init__(self, device_index: int):
-        self._tensor = torch.zeros((10_000_000,), dtype=torch.char, device=f"cuda:{device_index}")
+        self._tensor = torch.zeros((10_000_000,), dtype=torch.uint8, device=f"cuda:{device_index}")
         self._used_len = 0
 
     def allocate(self, size: int):

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -65,7 +65,7 @@ class _DebugPrinter:
 _printer: Optional[_DebugPrinter] = None
 
 
-def initialize(device_id: int):
+def initialize(device_id: Optional[int] = None):
     global _printer
     if _printer is not None:
         print("debug_print.initialize skip since already initialized")

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -48,6 +48,11 @@ class _DebugPrinter:
         name_cpu = torch.tensor(list(name_bytes) + [0], dtype=torch.uint8, device="cpu")
         copy_task = _CopyTask(src=name_cpu, dst=name_buffer_gpu)
 
+        if torch.cuda.is_current_stream_capturing():
+            self._pending_copy_tasks.append(copy_task)
+        else:
+            copy_task.execute()
+
 
 _printer: Optional[_DebugPrinter] = None
 

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -40,9 +40,9 @@ class _DebugPrinter:
             copy_task.execute()
         self._pending_copy_tasks.clear()
 
-    def __call__(self, x: torch.Tensor, name: str = "", print_ptr: bool = False):
+    def __call__(self, x: torch.Tensor, name: str, print_ptr: bool, print_shape: bool):
         name_buffer_gpu = self._compute_name_buffer_gpu(name=name, device_index=x.device.index)
-        _print_tensor_kernel(x, name_buffer_gpu, print_ptr)
+        _print_tensor_kernel(x, name_buffer_gpu, print_ptr, print_shape)
 
     def _compute_name_buffer_gpu(self, name: str, device_index: int):
         if len(name) == 0:
@@ -74,5 +74,5 @@ def post_initialize():
     _printer.post_initialize()
 
 
-def print_tensor(x: torch.Tensor, name: str = "", print_ptr: bool = False):
-    _printer(x=x, name=name, print_ptr=print_ptr)
+def print_tensor(x: torch.Tensor, name: str = "", print_ptr: bool = False, print_shape: bool = False):
+    _printer(x=x, name=name, print_ptr=print_ptr, print_shape=print_shape)

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -27,13 +27,12 @@ class _CopyTask:
 
 
 class _DebugPrinter:
-    def __init__(self):
+    def __init__(self, device_id: Optional[int]):
+        if device_id is None:
+            device_id = torch.cuda.current_device()
+
         # Can be optimized
-        self._buffers: Dict[int, _Buffer] = {
-            device_index: _Buffer(device_index=device_index)
-            # for device_index in range(torch.cuda.device_count())
-            for device_index in [torch.cuda.current_device()]
-        }
+        self._buffers: Dict[int, _Buffer] = {device_id: _Buffer(device_index=device_id)}
         self._pending_copy_tasks: List[_CopyTask] = []
 
     def post_initialize(self):
@@ -66,12 +65,12 @@ class _DebugPrinter:
 _printer: Optional[_DebugPrinter] = None
 
 
-def initialize():
+def initialize(device_id: int):
     global _printer
     if _printer is not None:
         print("debug_print.initialize skip since already initialized")
         return
-    _printer = _DebugPrinter()
+    _printer = _DebugPrinter(device_id=device_id)
 
 
 def post_initialize():

--- a/debug_print/__init__.py
+++ b/debug_print/__init__.py
@@ -26,9 +26,10 @@ class _DebugPrinter:
 
     def __call__(self, x: torch.Tensor, name: str = "", print_ptr: bool = False):
         if len(name) > 0:
-            name_bytes = TODO
-            name_buffer = self._buffers[x.device].allocate(len(name_bytes) + 1)
-            name_buffer.copy_(TODO)
+            name_bytes = name.encode("utf-8")
+            name_buffer = self._buffers[x.device.index].allocate(len(name_bytes) + 1)
+            tmp = torch.empty(list(name_bytes) + [0], dtype=torch.uint8, device="cpu")
+            name_buffer.copy_(tmp.to(name_buffer.device).view(torch.char))
         else:
             name_buffer = None
         _print_tensor_kernel(x, name_buffer, print_ptr)

--- a/example.py
+++ b/example.py
@@ -12,15 +12,16 @@ debug_print.print_tensor(x[..., 0])
 debug_print.print_tensor(x[0:1, 1:3, 0:4])
 
 print("demo for all types...")
-debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32), name="for int32")
-debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int64), name="for int64")
-debug_print.print_tensor(torch.tensor([1.5, 2.5, 3.5], dtype=torch.float), name="for float")
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32, device="cuda:0"), name="for int32")
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int64, device="cuda:0"), name="for int64")
+debug_print.print_tensor(torch.tensor([1.5, 2.5, 3.5], dtype=torch.float, device="cuda:0"), name="for float")
 
 print("demo for all dims...")
-debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32), name="for 1D")
-debug_print.print_tensor(torch.tensor([[1, 2, 3], [3, 4, 5]], dtype=torch.int32), name="for 2D")
-debug_print.print_tensor(torch.tensor([[[1, 2, 3], [3, 4, 5]], [[10, 20, 30], [30, 40, 50]]], dtype=torch.int32),
-                         name="for 3D")
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32, device="cuda:0"), name="for 1D")
+debug_print.print_tensor(torch.tensor([[1, 2, 3], [3, 4, 5]], dtype=torch.int32, device="cuda:0"), name="for 2D")
+debug_print.print_tensor(
+    torch.tensor([[[1, 2, 3], [3, 4, 5]], [[10, 20, 30], [30, 40, 50]]], dtype=torch.int32, device="cuda:0"),
+    name="for 3D")
 
 print("start warmup...")
 s = torch.cuda.Stream()

--- a/example.py
+++ b/example.py
@@ -32,6 +32,8 @@ with torch.cuda.graph(g, stream=s):
     z2 = z1 @ y
     debug_print.print_tensor(z2, name="This is name for z2")
 
+debug_print.post_initialize()
+
 x.copy_(torch.randn(2, 2))
 y.copy_(torch.ones(2, 2))
 print("start replay...")

--- a/example.py
+++ b/example.py
@@ -1,7 +1,6 @@
 import torch
 import debug_print
 
-print(f"{vars(debug_print)=} {dir(debug_print)=}")
 debug_print.initialize()
 
 x = torch.rand(3, 4, 5).to(0)

--- a/example.py
+++ b/example.py
@@ -27,9 +27,9 @@ with torch.cuda.graph(g, stream=s):
     z = x @ y
     debug_print.print_tensor(z)
     z1 = z @ y
-    debug_print.print_tensor(z1[..., 0])
+    debug_print.print_tensor(z1[..., 0], name="This is name for part of z1")
     z2 = z1 @ y
-    debug_print.print_tensor(z2)
+    debug_print.print_tensor(z2, name="This is name for z2")
 
 x.copy_(torch.randn(2, 2))
 y.copy_(torch.ones(2, 2))

--- a/example.py
+++ b/example.py
@@ -22,6 +22,14 @@ debug_print.print_tensor(torch.tensor([[1, 2, 3], [3, 4, 5]], dtype=torch.int32,
 debug_print.print_tensor(
     torch.tensor([[[1, 2, 3], [3, 4, 5]], [[10, 20, 30], [30, 40, 50]]], dtype=torch.int32, device="cuda:0"),
     name="for 3D", print_shape=True, print_ptr=True)
+debug_print.print_tensor(
+    torch.tensor(
+        [
+            [[[1, 2, 3], [3, 4, 5]], [[10, 20, 30], [30, 40, 50]]],
+            [[[-1, -2, -3], [-3, -4, -5]], [[-10, -20, -30], [-30, -40, -50]]],
+        ],
+        dtype=torch.int32, device="cuda:0"),
+    name="for 4D", print_shape=True, print_ptr=True)
 
 print("start warmup...")
 s = torch.cuda.Stream()

--- a/example.py
+++ b/example.py
@@ -3,6 +3,7 @@ import debug_print
 
 debug_print.initialize()
 
+print("demo without cuda graph...")
 x = torch.rand(3, 4, 5).to(0)
 debug_print.print_tensor(x)
 debug_print.print_tensor(x[..., 0:3])
@@ -10,6 +11,7 @@ x = torch.arange(3 * 4 * 5, dtype=torch.int32).view(3, 4, 5).to(0)
 debug_print.print_tensor(x[..., 0])
 debug_print.print_tensor(x[0:1, 1:3, 0:4])
 
+print("start warmup...")
 s = torch.cuda.Stream()
 s.wait_stream(torch.cuda.current_stream())
 x = torch.empty(2, 2).half().to(0)
@@ -21,6 +23,7 @@ with torch.cuda.stream(s):
         z2 = z1 @ y
 
 
+print("start graph capture...")
 g = torch.cuda.CUDAGraph()
 with torch.cuda.graph(g, stream=s):
     debug_print.print_tensor(x)

--- a/example.py
+++ b/example.py
@@ -1,6 +1,8 @@
 import torch
 import debug_print
 
+print(f"{vars(debug_print)=} {dir(debug_print)=}")
+debug_print.initialize()
 
 x = torch.rand(3, 4, 5).to(0)
 debug_print.print_tensor(x)

--- a/example.py
+++ b/example.py
@@ -12,16 +12,16 @@ debug_print.print_tensor(x[..., 0])
 debug_print.print_tensor(x[0:1, 1:3, 0:4])
 
 print("demo for all types...")
-debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32, device="cuda:0"), name="for int32")
-debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int64, device="cuda:0"), name="for int64")
-debug_print.print_tensor(torch.tensor([1.5, 2.5, 3.5], dtype=torch.float, device="cuda:0"), name="for float")
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32, device="cuda:0"), name="for int32", print_shape=True, print_ptr=True)
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int64, device="cuda:0"), name="for int64", print_shape=True, print_ptr=True)
+debug_print.print_tensor(torch.tensor([1.5, 2.5, 3.5], dtype=torch.float, device="cuda:0"), name="for float", print_shape=True, print_ptr=True)
 
 print("demo for all dims...")
-debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32, device="cuda:0"), name="for 1D")
-debug_print.print_tensor(torch.tensor([[1, 2, 3], [3, 4, 5]], dtype=torch.int32, device="cuda:0"), name="for 2D")
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32, device="cuda:0"), name="for 1D", print_shape=True, print_ptr=True)
+debug_print.print_tensor(torch.tensor([[1, 2, 3], [3, 4, 5]], dtype=torch.int32, device="cuda:0"), name="for 2D", print_shape=True, print_ptr=True)
 debug_print.print_tensor(
     torch.tensor([[[1, 2, 3], [3, 4, 5]], [[10, 20, 30], [30, 40, 50]]], dtype=torch.int32, device="cuda:0"),
-    name="for 3D")
+    name="for 3D", print_shape=True, print_ptr=True)
 
 print("start warmup...")
 s = torch.cuda.Stream()
@@ -42,7 +42,7 @@ with torch.cuda.graph(g, stream=s):
     z = x @ y
     debug_print.print_tensor(z)
     z1 = z @ y
-    debug_print.print_tensor(z1[..., 0], name="This is name for part of z1")
+    debug_print.print_tensor(z1[..., 0], name="This is name for part of z1", print_shape=True, print_ptr=True)
     z2 = z1 @ y
     debug_print.print_tensor(z2, name="This is name for z2")
 

--- a/example.py
+++ b/example.py
@@ -11,6 +11,17 @@ x = torch.arange(3 * 4 * 5, dtype=torch.int32).view(3, 4, 5).to(0)
 debug_print.print_tensor(x[..., 0])
 debug_print.print_tensor(x[0:1, 1:3, 0:4])
 
+print("demo for all types...")
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32), name="for int32")
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int64), name="for int64")
+debug_print.print_tensor(torch.tensor([1.5, 2.5, 3.5], dtype=torch.float), name="for float")
+
+print("demo for all dims...")
+debug_print.print_tensor(torch.tensor([3, 4, 5], dtype=torch.int32), name="for 1D")
+debug_print.print_tensor(torch.tensor([[1, 2, 3], [3, 4, 5]], dtype=torch.int32), name="for 2D")
+debug_print.print_tensor(torch.tensor([[[1, 2, 3], [3, 4, 5]], [[10, 20, 30], [30, 40, 50]]], dtype=torch.int32),
+                         name="for 3D")
+
 print("start warmup...")
 s = torch.cuda.Stream()
 s.wait_stream(torch.cuda.current_stream())
@@ -21,7 +32,6 @@ with torch.cuda.stream(s):
         z = x @ y
         z1 = z @ y
         z2 = z1 @ y
-
 
 print("start graph capture...")
 g = torch.cuda.CUDAGraph()

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 setup(
     name="debug_print",
     version="0.0.2",
+    packages=['debug_print'],
     ext_modules=[
         CUDAExtension(
             name="debug_print._kernels",


### PR DESCRIPTION
Close #1

API is suboptimal but I have no time to improve it currently, anyway it seems useable now.

output 

```
demo without cuda graph...

[[[0.0321, 0.9337, 0.2087, 0.6069, 0.7234, ], [0.3619, 0.8504, 0.5817, 0.5964, 0.5141, ], [0.7377, 0.5986, 0.0033, 0.6992, 0.9506, ], [0.7565, 0.6974, 0.4397, 0.2722, 0.0544, ], ], [[0.5629, 0.0225, 0.0032, 0.3086, 0.6959, ], [0.3602, 0.4634, 0.4939, 0.2671, 0.4978, ], [0.2733, 0.8136, 0.5757, 0.0800, 0.9290, ], [0.5862, 0.9824, 0.5481, 0.0201, 0.5500, ], ], [[0.6986, 0.0111, 0.3925, 0.7489, 0.4052, ], [0.7369, 0.8827, 0.6377, 0.9266, 0.3367, ], [0.5987, 0.4838, 0.3857, 0.7841, 0.5796, ], [0.6315, 0.3088, 0.9585, 0.2998, 0.3314, ], ], ]

[[[0.0321, 0.9337, 0.2087, ], [0.3619, 0.8504, 0.5817, ], [0.7377, 0.5986, 0.0033, ], [0.7565, 0.6974, 0.4397, ], ], [[0.5629, 0.0225, 0.0032, ], [0.3602, 0.4634, 0.4939, ], [0.2733, 0.8136, 0.5757, ], [0.5862, 0.9824, 0.5481, ], ], [[0.6986, 0.0111, 0.3925, ], [0.7369, 0.8827, 0.6377, ], [0.5987, 0.4838, 0.3857, ], [0.6315, 0.3088, 0.9585, ], ], ]

[[0, 5, 10, 15, ], [20, 25, 30, 35, ], [40, 45, 50, 55, ], ]

[[[5, 6, 7, 8, ], [10, 11, 12, 13, ], ], ]
demo for all types...
name=for int32, addr=140590144552960, shape=(3), stride=(1)
[3, 4, 5, ]
name=for int64, addr=140590144552960, shape=(3), stride=(1)
[3, 4, 5, ]
name=for float, addr=140590144552960, shape=(3), stride=(1)
[1.5000, 2.5000, 3.5000, ]
demo for all dims...
name=for 1D, addr=140590144552960, shape=(3), stride=(1)
[3, 4, 5, ]
name=for 2D, addr=140590144552960, shape=(2, 3), stride=(3, 1)
[[1, 2, 3, ], [3, 4, 5, ], ]
name=for 3D, addr=140590144552960, shape=(2, 2, 3), stride=(6, 3, 1)
[[[1, 2, 3, ], [3, 4, 5, ], ], [[10, 20, 30, ], [30, 40, 50, ], ], ]
start warmup...
start graph capture...
start replay...

[[-0.8896, -0.4331, ], [-1.0596, 1.5400, ], ]
addr=140590144553472, 
[[1.0000, 1.0000, ], [1.0000, 1.0000, ], ]

[[-1.3223, -1.3223, ], [0.4805, 0.4805, ], ]
name=This is name for part of z1, addr=140590329102848, shape=(2), stride=(2)
[-2.6445, 0.9609, ]
name=This is name for z2, 
[[-5.2891, -5.2891, ], [1.9219, 1.9219, ], ]
```